### PR TITLE
Update inkscapelite.petbuild

### DIFF
--- a/inkscapelite/inkscapelite.petbuild
+++ b/inkscapelite/inkscapelite.petbuild
@@ -6,7 +6,7 @@
 
 URL=http://distro.ibiblio.org/puppylinux/sources/i/
 PKG=inkscapelite
-VER=0.36.3_patched-glib
+VER=0.36.3_patched-glib-rulers
 COMP=tar.xz
 DESC="Light weight vector graphics editor"
 DEPS=+freetype2,+pango,+libxml2,+gtk+2,+cairo,+libpng,+atk


### PR DESCRIPTION
Patched sources for horizontal and vertical rulers uploaded to ibiblio/sources/i - this change amends the petbuild to match. Built and tested in slacko-6.3.0 and slacko-current (LxPup-15.11 and LxPupSc-16.04.2) 
