### PR TITLE
petbuilds-run_woof.sh (modified basic/build_all.sh and basic/func)

### DIFF
--- a/basic/func
+++ b/basic/func
@@ -1,7 +1,12 @@
 #!/bin/bash
 #functions library
 
-if [ -f ../build.conf ] ; then
+if [ -n "$z0base_dir" ] ; then
+	. ${z0base_dir}/build.conf
+	# if z0base_dir has been set,
+	# md5sumstxt, z0sources, z0pets_out, z0logs and MWD
+	# have already been set.
+elif [ -f ../build.conf ] ; then
 	. ../build.conf
 	md5sumstxt=../md5sums.txt
 	z0sources=../0sources

--- a/petbuilds-run_woof.sh
+++ b/petbuilds-run_woof.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+# For some reason there has to be a blank line between entries,
+# otherwise every other one gets skipped.
+DISTROS='
+http://distro.ibiblio.org/puppylinux/puppy-slacko-6.3.2/32/slacko-6.3.2-uefi.iso|http://distro.ibiblio.org/puppylinux/puppy-slacko-6.3.2/32/devx_slacko_6.3.2.sfs
+
+http://distro.ibiblio.org/puppylinux/puppy-slacko-6.3.2/64/slacko64-6.3.2-uefi.iso|http://distro.ibiblio.org/puppylinux/puppy-slacko-6.3.2/64/devx_slacko64_6.3.2.sfs
+
+http://distro.ibiblio.org/puppylinux/puppy-tahr/iso/tahrpup -6.0-CE/tahr-6.0.6-uefi.iso|http://distro.ibiblio.org/puppylinux/puppy-tahr/iso/tahrpup -6.0-CE/devx_tahr_6.0.6.sfs
+
+http://distro.ibiblio.org/puppylinux/puppy-tahr/iso/tahrpup -6.0-CE/tahr64-6.0.6-uefi.iso|http://distro.ibiblio.org/puppylinux/puppy-tahr/iso/tahrpup -6.0-CE/devx_tahr64_6.0.6.sfs
+'
+
+
+[ -d ../run_woof ] && cd ..
+if [ ! -d run_woof ]; then
+	echo "Cannot find run_woof."
+	exit 1
+fi
+
+# /tmp/petbuilds-bashrc is used in place of default run_woof bashrc
+echo '#!/bin/sh
+
+. /etc/profile
+
+PS1="run_woof\\$ "
+
+cd /root/share
+
+petbuilds/basic/build_all.sh '"$1"'
+
+[ "$?" = "0" ] && exit
+' > /tmp/petbuilds-bashrc
+
+# download any missing devx/ISOs
+while read -r ONE_DISTRO
+do
+	[ "$ONE_DISTRO" = "" ] && continue
+	IFS="|" read -r ISO_URL DEVX_URL <<< "$ONE_DISTRO"
+	ISO_NAME=${ISO_URL//*\/}
+	DEVX_NAME=${DEVX_URL//*\/}
+	[ ! -f "$ISO_NAME" ] && wget "$ISO_URL"
+	[ ! -f "$DEVX_NAME" ] && wget "$DEVX_URL"
+done <<< "${DISTROS}"
+
+# run the build once in each distro
+while read ONE_DISTRO
+do
+	[ "$ONE_DISTRO" = "" ] && continue
+	IFS="|" read -r ISO_URL DEVX_URL <<< "$ONE_DISTRO"
+	ISO_NAME=${ISO_URL//*\/}
+	DEVX_NAME=${DEVX_URL//*\/}
+
+	run_woof/run_woof $ISO_NAME $DEVX_NAME $PWD /tmp/petbuilds-bashrc
+
+done <<< "${DISTROS}"


### PR DESCRIPTION
If run_woof is available, petbuilds-run_woof.sh will download
devx/ISOs from ibiblio and run basic/build_all.sh
(you need to be running a 64bit kernel because of the 64bit ISOs)

Some pets won't build, and I'm not sure if the libs are in the
right place for the xenial64 pets, but it's a start.