### PR TITLE
basic/build_all.sh: Add ability to select ORDER-* file

### DIFF
--- a/basic/build_all.sh
+++ b/basic/build_all.sh
@@ -100,6 +100,19 @@ build_it() {
 	pkg=${1/\//} # remove trailing slash if using bash completion
 	case "$1" in
 		-h|-help|--help) usage ;;
+
+		# allow ORDER-* files to be selected from command line
+		*ORDER*)
+			if [ -f "$1" ]; then
+				zORDER="$1"
+				build_all
+				exit
+			elif [ -f "${z0base_dir}/$1" ]; then
+				zORDER="${z0base_dir}/$1"
+				build_all
+				exit
+			fi
+		;;
 	esac
 	[ -d "pkgs/$1" -o -d "${z0base_dir}/pkgs/$1" ] || usage
 	echo "

--- a/basic/md5sums.txt
+++ b/basic/md5sums.txt
@@ -26,3 +26,4 @@ d97474ae1954f772c6d2fa386a6f462c  ntfs-3g_ntfsprogs-2017.3.23.tgz
 1e224a6adbbe4ad40047b9fddbb0e60c  cdrtools-3.02a09.tar.bz2
 07b625a583b66c8c5840be5923f3e3fe  gptfdisk-1.0.3.tar.gz
 9ae2c6e7131cd2813edcc65cbe5f223f  smartmontools-6.6.tar.gz
+e144e4662ebe4ca5091df37352b82d28  gtkdialog-0.8.4.tar.xz


### PR DESCRIPTION
With the ability to have multiple ORDER-* files, all petbuilds
can be kept in a single pkgs directory.

It is also possible to keep local untracked ORDER-* files with
your own build lists.