### PR TITLE
New yad source repo

### DIFF
--- a/basic/md5sums.txt
+++ b/basic/md5sums.txt
@@ -105,3 +105,4 @@ b2a80e4789af23d67dfe1e88a997abbf  smartmontools-7.0.tar.gz
 c1572704a6211ecfe05c7f6ae362d09c  simple-mtpfs-0.3.0.tar.gz
 ed8dc48d7a3794e462e8e589a21746ce  rox-filer-17w.tar.gz
 d71720db03dfd02dfddfb4b2978e05f2  17wi.tar.gz
+f629e1783a62156a1efd0a24947bb87f  yad-0.42.39.tar.gz

--- a/basic/pkgs/versions
+++ b/basic/pkgs/versions
@@ -64,6 +64,6 @@ xclip_ver=0.13              # 2016-09-13   https://github.com/astrand/xclip/rele
 xcur2png_ver=0.7.0          # unchanging - old
 Xdialog_ver=2016.12         # unchanging
 xdotool_ver=                # -- requires libxkbcommon
-yad_ver=0.42.1              # last gtk2 version - https://github.com/v1cont/yad/releases
+yad_ver=0.42.39             # maintained gtk2 version - https://github.com/step-/yad/releases
 zarfy_ver=0.1.0             # unchaning  - old
 

--- a/basic/pkgs/yad/yad.petbuild
+++ b/basic/pkgs/yad/yad.petbuild
@@ -5,7 +5,7 @@
 . ../../func
 . ../../build.conf
 
-URL=https://github.com/v1cont/yad/archive
+URL=https://github.com/step-/yad/archive
 PKG=yad
 VER=$yad_ver
 COMP=tar.gz
@@ -28,7 +28,7 @@ case $ARCH in # set in build.conf
 esac
 
 # main
-retrieve v${VER}.${COMP} ${PKG}-${VER}.${COMP}
+retrieve ${VER}.${COMP} ${PKG}-${VER}.${COMP}
 extract ${PKG}-${VER}.${COMP}
 
 if [ ! -f ${PKG}-${VER}/configure ] ; then


### PR DESCRIPTION
Fatdog64 sources yad from this repo too.
Repo maintains GTK+ 2 source code with focus on bug fixing; some new features from the upstream yad repo can be backported.
[upstream yad vs maintain-gtk2 yad feature comparison status](https://github.com/step-/yad/blob/maintain-gtk2/feature-comparison.md)